### PR TITLE
chore: fix some typos in markdown file

### DIFF
--- a/nodes/running_testnet_rollup_node.md
+++ b/nodes/running_testnet_rollup_node.md
@@ -29,7 +29,7 @@ Please refer to the [Install Docker Engine](https://docs.docker.com/engine/insta
 Please refer to the [Install Docker Compose](https://docs.docker.com/compose/install/standalone/)
 
 ## Download configuration files
-Below is the releated files
+Below is the related files
 | Snapshot Data     | Size | Download Link | sha256sum
 | ----------- | ----------- | ----------- | ----------- |
 | 2024-08-23     | 4.0K     | [rollup.json](https://download.bsquared.network/testnet/rollup.json) | be7a590a5b4eb177c9953132f65be8cb0417ec47ccb2728c143da66a12c9eb2d

--- a/tech_architecture/architecture.md
+++ b/tech_architecture/architecture.md
@@ -1,4 +1,4 @@
-# Architecutre
+# Architecture
 
 The technical architecture of B² Network is shown in Figure [B² Network Architecture](https://ipfs.io/ipfs/QmNavFvPfkxeW5nti9WbGw2eCpZksfhzwgomuc7DK9eQjy). Comprising two fundamental layers, Rollup Layer and Data Availability Layer, B² Network seeks to redefine the way we perceive Bitcoin Layer-2 solutions.
 

--- a/tech_architecture/b2_nodes.md
+++ b/tech_architecture/b2_nodes.md
@@ -24,9 +24,9 @@ The Bitcoin Indexer monitors blocks and transactions on the Bitcoin network. Upo
 
 The Bitcoin Committer sends two types of transactions to Bitcoin: one that writes rollup data into Bitcoin, and another that writes the zk proof verification commitment into Bitcoin.
 
-- The Bitcoin Committer constructs a data structure to record B² rollup data and generates a Tapscript, known as a "B² Inscription." Then, the Bitcoin Committer sends a UTXO of one satoshi unit to a Taproot address containing the $B^{2}$ inscription. The rollup data is permanently written into Bitcoin. (See in Figure [Data availablity in B² Network](https://ipfs.io/ipfs/Qma2tcFRFA78cDNLDTZJzpa4fDWHR4TKGptc5Q6qpsS4yT))
+- The Bitcoin Committer constructs a data structure to record B² rollup data and generates a Tapscript, known as a "B² Inscription." Then, the Bitcoin Committer sends a UTXO of one satoshi unit to a Taproot address containing the $B^{2}$ inscription. The rollup data is permanently written into Bitcoin. (See in Figure [Data availability in B² Network](https://ipfs.io/ipfs/Qma2tcFRFA78cDNLDTZJzpa4fDWHR4TKGptc5Q6qpsS4yT))
 
-![Data availablity in B² Network](https://ipfs.io/ipfs/Qma2tcFRFA78cDNLDTZJzpa4fDWHR4TKGptc5Q6qpsS4yT)
+![Data availability in B² Network](https://ipfs.io/ipfs/Qma2tcFRFA78cDNLDTZJzpa4fDWHR4TKGptc5Q6qpsS4yT)
 
 - The Bitcoin Committer breaks down large computational units from the ZK Proof Verifier of Rollup Module into smaller computational units. Each small computational unit is then turned into a bit value commitment and placed in a tapleaf script. The zk proof of rollup serves as the input for the first bit value commitment, with the output being the input for the next commitment, eventually forming a taproot. The Bitcoin Committer sends a UTXO of one satoshi unit to a Taproot address containing the commitment. The commitment based on zk proof verification is permanently written into Bitcoin. Additionally, the Bitcoin Committer sets a time-locked challenge, allowing challengers to contest the zk proof verification commitment. If there are no challengers or the challenge fails within the time lock, the rollup is finally confirmed on Bitcoin; if the challenge succeeds, the rollup is rolled back. (See in Figure [Commitment in B² Network](https://ipfs.io/ipfs/QmUSxP47LiQ1PaddAiCHw1SuKHwNVXe9KPi3Ta7JLXurEc))
 


### PR DESCRIPTION
 fix some typos in markdown file